### PR TITLE
Add the support of setting baseCDN

### DIFF
--- a/src/defaultSettings.ts
+++ b/src/defaultSettings.ts
@@ -1,14 +1,8 @@
 import {version} from '../package.json'
 import {Settings} from './types'
 
-export type DefaultSettings = {
-  baseURL: string,
-  baseCDN: string,
-}
-
 /*
 Settings for future support:
-
   baseCDN: 'https://ucarecdn.com',
   multipartMinSize: 25 * 1024 * 1024,
   multipartPartSize: 5 * 1024 * 1024,
@@ -18,9 +12,9 @@ Settings for future support:
   parallelDirectUploads: 10,
   pusherKey: '79ae88bd931ea68464d9',
  */
-const defaultSettings: DefaultSettings = {
-  baseURL: 'https://upload.uploadcare.com',
+const defaultSettings: Settings = {
   baseCDN: 'https://ucarecdn.com',
+  baseURL: 'https://upload.uploadcare.com',
 }
 
 export default defaultSettings

--- a/src/fileFrom.ts
+++ b/src/fileFrom.ts
@@ -52,7 +52,7 @@ export class FilePromise {
         }
 
         return checkFileIsReady(uuid, (info) => {
-          this.file = prettyFileInfo(info)
+          this.file = prettyFileInfo(info, settings)
         }, 100, settings)
       })
       .then(() => {

--- a/src/prettyFileInfo.ts
+++ b/src/prettyFileInfo.ts
@@ -1,15 +1,16 @@
 import defaultSettings from './defaultSettings'
 import camelizeKeys from './tools/camelizeKeys'
 import {InfoResponse} from './api/info'
-import {UFile} from './types'
+import {Settings, UFile} from './types'
 
 /**
  * Transforms file info getting from Upload API to pretty info
  *
  * @param {InfoResponse} info
+ * @param {Settings} settings
  * @returns {UFile}
  */
-export default function prettyFileInfo(info: InfoResponse): UFile {
+export default function prettyFileInfo(info: InfoResponse, settings: Settings = {}): UFile {
   const {
     uuid,
     filename,
@@ -23,9 +24,13 @@ export default function prettyFileInfo(info: InfoResponse): UFile {
     s3Bucket,
   } = camelizeKeys(info)
 
+  const extendedSettings = {
+    ...defaultSettings,
+    ...settings,
+  }
   const urlBase = s3Bucket
     ? `https://${s3Bucket}.s3.amazonaws.com/${fileId}/${filename}`
-    : `${defaultSettings.baseCDN}/${fileId}/`
+    : `${extendedSettings.baseCDN}/${fileId}/`
   const cdnUrlModifiers = defaultEffects ? '-/' + defaultEffects : null
   const cdnUrl = fileId ? urlBase + (cdnUrlModifiers || '') : null
   const originalUrl = fileId ? urlBase : null

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,4 +1,5 @@
 export type Settings = {
+  baseCDN?: string,
   baseURL?: string,
   publicKey?: string | null,
   doNotStore?: boolean,


### PR DESCRIPTION
Replace `DefaultSettings` type with `Settings` for consistency. Add `settings` option to `prettyFileInfo`. Add `baseCDN` option to `Settings` type.