### PR TITLE
fix: make `fileName` optional and remove it from default settings

### DIFF
--- a/src/api/base.ts
+++ b/src/api/base.ts
@@ -2,7 +2,7 @@ import request from '../request/request.node'
 import getFormData from '../tools/buildFormData'
 import getUrl from '../tools/getUrl'
 import CancelController from '../tools/CancelController'
-import defaultSettings from '../defaultSettings'
+import { defaultSettings, defaultFilename } from '../defaultSettings'
 import { getUserAgent } from '../tools/userAgent'
 import camelizeKeys from '../tools/camelizeKeys'
 import { UploadClientError } from '../tools/errors'
@@ -67,11 +67,7 @@ export default function base(
           'X-UC-User-Agent': getUserAgent({ publicKey, integration })
         },
         data: getFormData([
-          [
-            'file',
-            file,
-            fileName || (file as File).name || defaultSettings.fileName
-          ],
+          ['file', file, fileName ?? (file as File).name ?? defaultFilename],
           ['UPLOADCARE_PUB_KEY', publicKey],
           [
             'UPLOADCARE_STORE',

--- a/src/api/multipartStart.ts
+++ b/src/api/multipartStart.ts
@@ -4,7 +4,7 @@ import { Uuid } from './types'
 import request from '../request/request.node'
 import getFormData from '../tools/buildFormData'
 import getUrl from '../tools/getUrl'
-import defaultSettings from '../defaultSettings'
+import { defaultSettings, defaultFilename } from '../defaultSettings'
 import { getUserAgent } from '../tools/userAgent'
 import camelizeKeys from '../tools/camelizeKeys'
 import retryIfThrottled from '../tools/retryIfThrottled'
@@ -43,7 +43,7 @@ export default function multipartStart(
   {
     publicKey,
     contentType,
-    fileName = defaultSettings.fileName,
+    fileName,
     multipartChunkSize = defaultSettings.multipartChunkSize,
     baseURL = '',
     secureSignature,
@@ -64,7 +64,7 @@ export default function multipartStart(
           'X-UC-User-Agent': getUserAgent({ publicKey, integration })
         },
         data: getFormData([
-          ['filename', fileName],
+          ['filename', fileName ?? defaultFilename],
           ['size', size],
           ['content_type', contentType],
           ['part_size', multipartChunkSize],

--- a/src/defaultSettings.ts
+++ b/src/defaultSettings.ts
@@ -8,7 +8,6 @@ import { DefaultSettings } from './types'
 const defaultSettings: DefaultSettings = {
   baseCDN: 'https://ucarecdn.com',
   baseURL: 'https://upload.uploadcare.com',
-  fileName: 'original',
   maxContentLength: 50 * 1024 * 1024, // 50 MB
   retryThrottledRequestMaxTimes: 1,
   multipartMinFileSize: 25 * 1024 * 1024, // 25 MB
@@ -20,4 +19,7 @@ const defaultSettings: DefaultSettings = {
   pusherKey: '79ae88bd931ea68464d9'
 }
 
+const defaultFilename = 'original'
+
+export { defaultFilename, defaultSettings }
 export default defaultSettings

--- a/src/types.ts
+++ b/src/types.ts
@@ -8,7 +8,6 @@ type Partial<T> = {
 export interface DefaultSettings {
   baseCDN: string
   baseURL: string
-  fileName: string
   maxContentLength: number
   retryThrottledRequestMaxTimes: number
   multipartMinFileSize: number
@@ -22,6 +21,7 @@ export interface DefaultSettings {
 
 export interface Settings extends Partial<DefaultSettings> {
   publicKey?: string
+  fileName?: string
   store?: boolean
   secureSignature?: string
   secureExpire?: string

--- a/src/uploadFile/index.ts
+++ b/src/uploadFile/index.ts
@@ -56,7 +56,7 @@ export default function uploadFile(
   {
     publicKey,
 
-    fileName = defaultSettings.fileName,
+    fileName,
     baseURL = defaultSettings.baseURL,
     secureSignature,
     secureExpire,

--- a/src/uploadFileGroup/index.ts
+++ b/src/uploadFileGroup/index.ts
@@ -38,7 +38,7 @@ export default function uploadFileGroup(
   {
     publicKey,
 
-    fileName = defaultSettings.fileName,
+    fileName,
     baseURL = defaultSettings.baseURL,
     secureSignature,
     secureExpire,


### PR DESCRIPTION
## Description

Fix #224

drop `default` filename, because all uploaded files have default name in this case

## Checklist

- [ ] Tests (if applicable)
- [ ] Documentation (if applicable)
