### PR TITLE
test: run master test with node v12

### DIFF
--- a/.github/workflows/shipjs-trigger.yml
+++ b/.github/workflows/shipjs-trigger.yml
@@ -12,6 +12,7 @@ jobs:
       - uses: actions/setup-node@v1
         with:
           registry-url: "https://registry.npmjs.org"
+          node-version: '12'
       - run: git switch master
       - run: |
           if [ -f "yarn.lock" ]; then


### PR DESCRIPTION
## Description

JSDOM throws this error on node v10:
https://github.com/uploadcare/uploadcare-upload-client/runs/897175748?check_suite_focus=true#step:6:31

so i update node to v12

related issue https://github.com/jsdom/jsdom/issues/2961


## Checklist

- [ ] Tests (if applicable)
- [ ] Documentation (if applicable)
- [ ] Changelog stub (or use [conventional commit messages](https://www.conventionalcommits.org/))
