### PR TITLE
fix(react-native): support direct uploads through FormData

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,11 @@
     "./lib/tools/getFormData.node.js": "./lib/tools/getFormData.browser.js",
     "./lib/tools/sockets.node.js": "./lib/tools/sockets.browser.js"
   },
+  "react-native": {
+    "./lib/request/request.node.js": "./lib/request/request.browser.js",
+    "./lib/tools/getFormData.node.js": "./lib/tools/getFormData.react-native.js",
+    "./lib/tools/sockets.node.js": "./lib/tools/sockets.browser.js"
+  },
   "scripts": {
     "check-env-vars": "node ./checkvars.js",
     "mock:start": "ts-node --project ./mock-server/tsconfig.mock.json ./mock-server/server.ts --silent",
@@ -52,9 +57,9 @@
     "@types/koa": "2.11.4",
     "@types/node": "12.12.67",
     "@types/promise": "7.1.30",
+    "@types/ws": "7.2.7",
     "@typescript-eslint/eslint-plugin": "2.34.0",
     "@typescript-eslint/parser": "2.34.0",
-    "@types/ws": "7.2.7",
     "chalk": "4.1.0",
     "data-uri-to-buffer": "3.0.1",
     "dataurl-to-blob": "0.0.1",
@@ -74,8 +79,8 @@
     "rimraf": "3.0.2",
     "shipjs": "0.22.0",
     "start-server-and-test": "1.11.5",
-    "ts-node": "8.10.2",
     "ts-jest": "26.4.1",
+    "ts-node": "8.10.2",
     "typescript": "3.9.7"
   },
   "dependencies": {

--- a/src/tools/buildFormData.ts
+++ b/src/tools/buildFormData.ts
@@ -9,15 +9,15 @@ import { BrowserFile, NodeFile } from '../request/types'
  * in browsers.
  */
 
-type FileTriple = ['file', BrowserFile | NodeFile, string]
+type FileTuple = ['file', BrowserFile | NodeFile, string]
 type BaseType = string | number | void
 type FormDataTuple = [string, BaseType | BaseType[]]
 
-const isFileTriple = (tuple: FormDataTuple | FileTriple): tuple is FileTriple =>
+const isFileTuple = (tuple: FormDataTuple | FileTuple): tuple is FileTuple =>
   tuple[0] === 'file'
 
 function buildFormData(
-  body: (FormDataTuple | FileTriple)[]
+  body: (FormDataTuple | FileTuple)[]
 ): FormData | NodeFormData {
   const formData = getFormData()
 
@@ -25,7 +25,7 @@ function buildFormData(
     if (Array.isArray(tuple[1])) {
       // refactor this
       tuple[1].forEach(val => val && formData.append(tuple[0] + '[]', `${val}`))
-    } else if (isFileTriple(tuple)) {
+    } else if (isFileTuple(tuple)) {
       const name = tuple[2]
       const file = transformFile(tuple[1], name) as Blob // lgtm[js/superfluous-trailing-arguments]
       formData.append(tuple[0], file, name)

--- a/src/tools/buildFormData.ts
+++ b/src/tools/buildFormData.ts
@@ -27,7 +27,7 @@ function buildFormData(
       tuple[1].forEach(val => val && formData.append(tuple[0] + '[]', `${val}`))
     } else if (isFileTriple(tuple)) {
       const name = tuple[2]
-      const file = transformFile(tuple[1], name) as Blob
+      const file = transformFile(tuple[1], name) as Blob // lgtm[js/superfluous-trailing-arguments]
       formData.append(tuple[0], file, name)
     } else if (tuple[1] != null) {
       formData.append(tuple[0], `${tuple[1]}`)

--- a/src/tools/getFormData.browser.ts
+++ b/src/tools/getFormData.browser.ts
@@ -1,1 +1,5 @@
+import { FileTransformer } from './types'
+import { identity } from './identity'
+
+export const transformFile: FileTransformer = identity
 export default (): FormData => new FormData()

--- a/src/tools/getFormData.node.ts
+++ b/src/tools/getFormData.node.ts
@@ -1,3 +1,6 @@
 import * as NodeFormData from 'form-data'
+import { FileTransformer } from './types'
+import { identity } from './identity'
 
+export const transformFile: FileTransformer = identity
 export default (): NodeFormData | FormData => new NodeFormData()

--- a/src/tools/getFormData.react-native.ts
+++ b/src/tools/getFormData.react-native.ts
@@ -1,0 +1,16 @@
+import { BrowserFile, NodeFile } from '../request/types'
+import { FileTransformer, ReactNativeAsset } from './types'
+
+export const transformFile: FileTransformer = (
+  file: BrowserFile | NodeFile,
+  name: string
+): ReactNativeAsset => {
+  if (!file) {
+    return file
+  }
+  const uri = URL.createObjectURL(file)
+  const type = (file as BrowserFile).type
+  return { uri, name, type }
+}
+
+export default (): FormData => new FormData()

--- a/src/tools/identity.ts
+++ b/src/tools/identity.ts
@@ -1,0 +1,3 @@
+export function identity<T>(obj: T): T {
+  return obj
+}

--- a/src/tools/types.ts
+++ b/src/tools/types.ts
@@ -1,0 +1,8 @@
+import { BrowserFile, NodeFile } from '../request/types'
+
+export type ReactNativeAsset = { name?: string; type?: string; uri: string }
+
+export type FileTransformer = (
+  file: NodeFile | BrowserFile,
+  name: string
+) => NodeFile | BrowserFile | ReactNativeAsset


### PR DESCRIPTION
Fixes #306 

## Description

We upload small files through XHR and FormData. React-Native has its own implementation of XHR, FormData, Blobs, Files and everything else. And FormData for some reason doesn't support Blob arguments, instead it takes an object of type `{ name?: string; type?: string; uri: string }` (see https://github.com/facebook/react-native/blob/master/Libraries/Network/FormData.js#L37)