### PR TITLE
fix: pass missing props from `uploadFile` down to the upload methods

### DIFF
--- a/src/uploadFile/index.ts
+++ b/src/uploadFile/index.ts
@@ -31,11 +31,14 @@ export type FileFromOptions = {
 
   contentType?: string
   multipartChunkSize?: number
+  multipartMaxAttempts?: number
+  maxConcurrentRequests?: number
 
   baseCDN?: string
 
   checkForUrlDuplicates?: boolean
   saveUrlForRecurrentUploads?: boolean
+  pusherKey?: string
 }
 
 /**
@@ -53,8 +56,13 @@ export type FileFromOptions = {
  * @param [options.source]
  * @param [options.integration]
  * @param [options.retryThrottledRequestMaxTimes]
+ * @param [options.contentType]
+ * @param [options.multipartChunkSize]
+ * @param [options.multipartMaxAttempts]
+ * @param [options.maxConcurrentRequests]
  * @param [options.checkForUrlDuplicates]
  * @param [options.saveUrlForRecurrentUploads]
+ * @param [options.pusherKey]
  */
 export default function uploadFile(
   data: NodeFile | BrowserFile | Url | Uuid,
@@ -76,12 +84,15 @@ export default function uploadFile(
     retryThrottledRequestMaxTimes,
 
     contentType,
-    multipartChunkSize = defaultSettings.multipartChunkSize,
+    multipartChunkSize,
+    multipartMaxAttempts,
+    maxConcurrentRequests,
 
     baseCDN = defaultSettings.baseCDN,
 
     checkForUrlDuplicates,
-    saveUrlForRecurrentUploads
+    saveUrlForRecurrentUploads,
+    pusherKey
   }: FileFromOptions
 ): Promise<UploadcareFile> {
   if (isFileData(data)) {
@@ -92,6 +103,7 @@ export default function uploadFile(
         publicKey,
         contentType,
         multipartChunkSize,
+        multipartMaxAttempts,
 
         fileName,
         baseURL,
@@ -105,6 +117,7 @@ export default function uploadFile(
         source,
         integration,
 
+        maxConcurrentRequests,
         retryThrottledRequestMaxTimes,
 
         baseCDN
@@ -138,6 +151,9 @@ export default function uploadFile(
 
       fileName,
       baseURL,
+      baseCDN,
+      checkForUrlDuplicates,
+      saveUrlForRecurrentUploads,
       secureSignature,
       secureExpire,
       store,
@@ -149,11 +165,7 @@ export default function uploadFile(
       integration,
 
       retryThrottledRequestMaxTimes,
-
-      baseCDN,
-
-      checkForUrlDuplicates,
-      saveUrlForRecurrentUploads
+      pusherKey
     })
   }
 

--- a/test/uploadFile/fileFromUrl.test.ts
+++ b/test/uploadFile/fileFromUrl.test.ts
@@ -3,6 +3,8 @@ import uploadFile from '../../src/uploadFile'
 import { getSettingsForTesting } from '../_helpers'
 import { UploadClientError } from '../../src/tools/errors'
 import CancelController from '../../src/tools/CancelController'
+import * as http from 'http'
+import * as https from 'https'
 
 describe('uploadFrom URL', () => {
   it('should resolves when file is ready on CDN', async () => {
@@ -27,6 +29,44 @@ describe('uploadFrom URL', () => {
     const file = await uploadFile(sourceUrl, settings)
 
     expect(file.isStored).toBeFalsy()
+  })
+
+  it('should accept checkForUrlDuplicates setting', async () => {
+    const sourceUrl = factory.imageUrl('valid')
+    const settings = getSettingsForTesting({
+      publicKey: factory.publicKey('image'),
+      checkForUrlDuplicates: true
+    })
+
+    const isHttpsProtocol = settings.baseURL.includes('https')
+    const spy = jest.spyOn(isHttpsProtocol ? https : http, 'request')
+    await uploadFile(sourceUrl, settings)
+
+    const uploadRequest = spy.mock.calls[0][0]
+    expect(uploadRequest['query']).toEqual(
+      expect.stringContaining('check_URL_duplicates=1')
+    )
+    spy.mockClear()
+  })
+
+  it('should accept saveUrlForRecurrentUploads setting', async () => {
+    const sourceUrl = factory.imageUrl('valid')
+    const settings = getSettingsForTesting({
+      publicKey: factory.publicKey('image'),
+      saveUrlForRecurrentUploads: true
+    })
+
+    const isHttpsProtocol = settings.baseURL.includes('https')
+      ? 'https'
+      : 'http'
+    const spy = jest.spyOn(isHttpsProtocol ? https : http, 'request')
+    await uploadFile(sourceUrl, settings)
+
+    const uploadRequest = spy.mock.calls[0][0]
+    expect(uploadRequest['query']).toEqual(
+      expect.stringContaining('save_URL_duplicates=1')
+    )
+    spy.mockClear()
   })
 
   it('should be able to cancel uploading', async () => {


### PR DESCRIPTION
I have checked all the properties, except for the `checkForUrlDuplicates` and `saveUrlForRecurrentUploads`, and found out a few ones that aren't passed down from `uploadFile` method. 

1. `multipartMaxAttempts` and `maxConcurrentRequests` should be passed to the multipart upload method
2. `pusherKey` should be passed to the from url method

I fixed them.

Also I added tests for `checkForUrlDuplicates` and `saveUrlForRecurrentUploads` that check the presence of proper keys inside http/https request. 