### PR TITLE
Fix sending signed API requests with body in Firefox

### DIFF
--- a/packages/rest-client/src/makeApiRequest.ts
+++ b/packages/rest-client/src/makeApiRequest.ts
@@ -65,6 +65,7 @@ export async function makeApiRequest(
   if (!settings.authSchema) {
     throw new RestClientError('authSchema is required')
   }
+
   const url = getRequestURL(path, query, settings.apiBaseURL)
   const requestBody = body && JSON.stringify(body)
   const unsignedRequest = new Request(url, {
@@ -79,10 +80,12 @@ export async function makeApiRequest(
       })
     })
   })
+
   const requestHeaders = await settings.authSchema.getHeaders(unsignedRequest)
-  const signedRequest = new Request(unsignedRequest, {
-    headers: requestHeaders,
-    body: requestBody
+  const signedRequest = new Request(url, {
+    method: method,
+    body: requestBody,
+    headers: requestHeaders
   })
 
   const response = await retryIfFailed(() => fetch(signedRequest), {


### PR DESCRIPTION
## Description

Firefox [doesn't support](https://developer.mozilla.org/en-US/docs/Web/API/Request/body#browser_compatibility) `Request.body`, so new `Request(prevRequest, {})` for requests with body leads to "Body has already been consumed" error.

<!-- Write a brief description of the changes introduced by this PR -->

<!-- Provide code snippets / GIFs or screenshots, if it makes sense -->


## Checklist

- [ ] Tests (if applicable)
- [ ] Documentation (if applicable)
- [ ] Changelog stub (or use [conventional commit messages](https://www.conventionalcommits.org/))
