### PR TITLE
fix(types): make `UploadcareFile` instance properties non-nullable cause they're can't be `null` actually

### DIFF
--- a/packages/upload-client/src/tools/UploadcareFile.ts
+++ b/packages/upload-client/src/tools/UploadcareFile.ts
@@ -15,19 +15,19 @@ function isGroupFileInfo(
 }
 export class UploadcareFile {
   readonly uuid: Uuid
-  readonly name: null | string = null
-  readonly size: null | number = null
-  readonly isStored: null | boolean = null
-  readonly isImage: null | boolean = null
-  readonly mimeType: null | string = null
-  readonly cdnUrl: null | string = null
-  readonly s3Url: null | string = null
-  readonly originalFilename: null | string = null
-  readonly imageInfo: null | ImageInfo = null
-  readonly videoInfo: null | VideoInfo = null
-  readonly contentInfo: null | ContentInfo = null
-  readonly metadata: null | Metadata = null
-  readonly s3Bucket: null | string = null
+  readonly name: string
+  readonly size: number
+  readonly isStored: boolean
+  readonly isImage: boolean
+  readonly mimeType: string
+  readonly cdnUrl: string
+  readonly s3Url: string | null
+  readonly originalFilename: string
+  readonly imageInfo: ImageInfo | null
+  readonly videoInfo: VideoInfo | null
+  readonly contentInfo: ContentInfo | null
+  readonly metadata: Metadata | null
+  readonly s3Bucket: string | null
   readonly defaultEffects: null | string = null
 
   constructor(


### PR DESCRIPTION
## Description

<!-- Link to the related issue -->

<!-- Write a brief description of the changes introduced by this PR -->

<!-- Provide code snippets / GIFs or screenshots, if it makes sense -->


## Checklist

- [ ] Tests (if applicable)
- [ ] Documentation (if applicable)
- [ ] Changelog stub (or use [conventional commit messages](https://www.conventionalcommits.org/))
