### PR TITLE
ci: migrate npm publish to staged publishing

### DIFF
--- a/.github/workflows/shipjs-trigger.yml
+++ b/.github/workflows/shipjs-trigger.yml
@@ -9,13 +9,15 @@ jobs:
     runs-on: ubuntu-latest
     if: github.event.pull_request.merged == true && startsWith(github.head_ref, 'releases/v')
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
           ref:  master
       - uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 22
+      - name: Pin npm with staged publishing support
+        run: npm install -g npm@">=11.15.0"
       - run: npm ci
       - run: |
           git config --global user.email "github-actions[bot]@users.noreply.github.com"
@@ -24,3 +26,20 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_AUTH_TOKEN: ${{ secrets.NPM_AUTH_TOKEN }}
+      - name: Read release version
+        id: ver
+        run: echo "version=$(node -p "require('./package.json').version")" >> "$GITHUB_OUTPUT"
+      - name: Notify Slack about staged release
+        uses: slackapi/slack-github-action@37ebaef184d7626c5f204ab8d3baff4262dd30f0 # v1.27.0
+        env:
+          SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
+        with:
+          channel-id: ${{ secrets.SLACK_NPM_RELEASE_CHANNEL }}
+          slack-message: |
+            :package: *@uploadcare/api-clients v${{ steps.ver.outputs.version }}* staged for review (2FA required to approve each):
+            • <https://www.npmjs.com/package/@uploadcare/upload-client?activeTab=staged|@uploadcare/upload-client>
+            • <https://www.npmjs.com/package/@uploadcare/rest-client?activeTab=staged|@uploadcare/rest-client>
+            • <https://www.npmjs.com/package/@uploadcare/signed-uploads?activeTab=staged|@uploadcare/signed-uploads>
+            • <https://www.npmjs.com/package/@uploadcare/image-shrink?activeTab=staged|@uploadcare/image-shrink>
+            • <https://www.npmjs.com/package/@uploadcare/quality-insights?activeTab=staged|@uploadcare/quality-insights>
+            • <https://www.npmjs.com/package/@uploadcare/cname-prefix?activeTab=staged|@uploadcare/cname-prefix>

--- a/package-lock.json
+++ b/package-lock.json
@@ -27,7 +27,7 @@
         "@rollup/plugin-node-resolve": "^15.0.1",
         "@rollup/plugin-typescript": "^11.1.6",
         "@types/jest": "^29.5.12",
-        "@types/node": "^16.11.7",
+        "@types/node": "^22",
         "@typescript-eslint/eslint-plugin": "^7.0.1",
         "@typescript-eslint/parser": "^7.0.1",
         "chalk": "4.1.2",
@@ -3471,9 +3471,14 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "16.18.18",
+      "version": "22.19.20",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.20.tgz",
+      "integrity": "sha512-6tELRwSDYWW9EdZhbeZmYGZ1/7Djkt+Ah3/ScEYT9cDord7UJzasR/4D3VONg9tQI5CDp+/CZC1AXj2pCFOvpw==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
     },
     "node_modules/@types/node-fetch": {
       "version": "2.6.2",
@@ -3500,6 +3505,13 @@
       "engines": {
         "node": ">= 6"
       }
+    },
+    "node_modules/@types/node/node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/normalize-package-data": {
       "version": "2.4.4",
@@ -11922,7 +11934,6 @@
       "os": [
         "darwin"
       ],
-      "peer": true,
       "engines": {
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
@@ -13253,19 +13264,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/source-map-support": {
-      "version": "0.5.21",
-      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz",
-      "integrity": "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "buffer-from": "^1.0.0",
-        "source-map": "^0.6.0"
-      }
-    },
     "node_modules/spdx-correct": {
       "version": "3.1.1",
       "dev": true,
@@ -14273,15 +14271,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/undici-types": {
-      "version": "7.8.0",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.8.0.tgz",
-      "integrity": "sha512-9UJ2xGDvQ43tYyVMpuHlsgApydB8ZKfVYTsLDhXkFL/6gfkp+U8xTGdh8pMJv1SpZna0zxG1DwsKZsreLbXBxw==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true
-    },
     "node_modules/unist-util-stringify-position": {
       "version": "4.0.0",
       "dev": true,
@@ -14878,18 +14867,6 @@
       ],
       "engines": {
         "node": ">=18"
-      }
-    },
-    "node_modules/vite-node/node_modules/@types/node": {
-      "version": "24.0.3",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.0.3.tgz",
-      "integrity": "sha512-R4I/kzCYAdRLzfiCabn9hxWfbuHS573x+r0dJMkkzThEa7pbrcDWK+9zu3e7aBOouf+rQAciqPFMnxwr0aWgKg==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "undici-types": "~7.8.0"
       }
     },
     "node_modules/vite-node/node_modules/esbuild": {
@@ -16050,17 +16027,6 @@
         "node": ">=18"
       }
     },
-    "packages/cname-prefix/node_modules/@jridgewell/source-map": {
-      "version": "0.3.6",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@jridgewell/gen-mapping": "^0.3.5",
-        "@jridgewell/trace-mapping": "^0.3.25"
-      }
-    },
     "packages/cname-prefix/node_modules/@rollup/rollup-android-arm-eabi": {
       "version": "4.55.2",
       "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.55.2.tgz",
@@ -16313,16 +16279,6 @@
         "win32"
       ]
     },
-    "packages/cname-prefix/node_modules/@types/node": {
-      "version": "22.15.30",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "undici-types": "~6.21.0"
-      }
-    },
     "packages/cname-prefix/node_modules/@vitest/browser": {
       "version": "3.2.4",
       "resolved": "https://registry.npmjs.org/@vitest/browser/-/browser-3.2.4.tgz",
@@ -16429,13 +16385,6 @@
       "dependencies": {
         "balanced-match": "^1.0.0"
       }
-    },
-    "packages/cname-prefix/node_modules/commander": {
-      "version": "2.20.3",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true
     },
     "packages/cname-prefix/node_modules/esbuild": {
       "version": "0.27.2",
@@ -16611,25 +16560,6 @@
         "fsevents": "~2.3.2"
       }
     },
-    "packages/cname-prefix/node_modules/terser": {
-      "version": "5.41.0",
-      "dev": true,
-      "license": "BSD-2-Clause",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@jridgewell/source-map": "^0.3.3",
-        "acorn": "^8.14.0",
-        "commander": "^2.20.0",
-        "source-map-support": "~0.5.20"
-      },
-      "bin": {
-        "terser": "bin/terser"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "packages/cname-prefix/node_modules/test-exclude": {
       "version": "7.0.1",
       "dev": true,
@@ -16642,13 +16572,6 @@
       "engines": {
         "node": ">=18"
       }
-    },
-    "packages/cname-prefix/node_modules/undici-types": {
-      "version": "6.21.0",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true
     },
     "packages/cname-prefix/node_modules/vite": {
       "version": "7.3.1",
@@ -17271,18 +17194,6 @@
       ],
       "engines": {
         "node": ">=18"
-      }
-    },
-    "packages/image-shrink/node_modules/@types/node": {
-      "version": "24.0.3",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.0.3.tgz",
-      "integrity": "sha512-R4I/kzCYAdRLzfiCabn9hxWfbuHS573x+r0dJMkkzThEa7pbrcDWK+9zu3e7aBOouf+rQAciqPFMnxwr0aWgKg==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "undici-types": "~7.8.0"
       }
     },
     "packages/image-shrink/node_modules/@vitest/browser": {
@@ -18171,17 +18082,6 @@
       ],
       "engines": {
         "node": ">=18"
-      }
-    },
-    "packages/quality-insights/node_modules/@types/node": {
-      "version": "24.0.3",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.0.3.tgz",
-      "integrity": "sha512-R4I/kzCYAdRLzfiCabn9hxWfbuHS573x+r0dJMkkzThEa7pbrcDWK+9zu3e7aBOouf+rQAciqPFMnxwr0aWgKg==",
-      "dev": true,
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "undici-types": "~7.8.0"
       }
     },
     "packages/quality-insights/node_modules/@vitest/coverage-v8": {

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "@rollup/plugin-node-resolve": "^15.0.1",
     "@rollup/plugin-typescript": "^11.1.6",
     "@types/jest": "^29.5.12",
-    "@types/node": "^16.11.7",
+    "@types/node": "^22",
     "@typescript-eslint/eslint-plugin": "^7.0.1",
     "@typescript-eslint/parser": "^7.0.1",
     "chalk": "4.1.2",

--- a/ship.config.mjs
+++ b/ship.config.mjs
@@ -14,7 +14,7 @@ export default {
       'packages/cname-prefix',
     ]
   },
-  publishCommand: ({ defaultCommand }) => `${defaultCommand} --access public`,
+  publishCommand: ({ tag }) => `npm stage publish --tag ${tag}`,
   versionUpdated: ({ version, dir }) => {
     const packages = [
       'upload-client',


### PR DESCRIPTION
Migrates npm releases to [staged publishing](https://docs.npmjs.com/trusted-publishers#staged-publishing).