### PR TITLE
feat(upload-client): use prefixed CDN domains by default

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11934,6 +11934,7 @@
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
@@ -18560,6 +18561,7 @@
         "@types/koa__router": "^12.0.4",
         "@types/ws": "8.5.3",
         "@uploadcare/api-client-utils": "^6.18.4",
+        "@uploadcare/cname-prefix": "^6.18.4",
         "chalk": "^4.1.2",
         "data-uri-to-buffer": "3.0.1",
         "dataurl-to-blob": "0.0.1",

--- a/package.json
+++ b/package.json
@@ -6,12 +6,12 @@
   "license": "MIT",
   "workspaces": [
     "packages/api-client-utils",
+    "packages/cname-prefix",
     "packages/upload-client",
     "packages/rest-client",
     "packages/signed-uploads",
     "packages/image-shrink",
-    "packages/quality-insights",
-    "packages/cname-prefix"
+    "packages/quality-insights"
   ],
   "engines": {
     "node": ">=16"

--- a/packages/cname-prefix/src/common/isPrefixedCdnBase.test.ts
+++ b/packages/cname-prefix/src/common/isPrefixedCdnBase.test.ts
@@ -31,4 +31,17 @@ describe('isPrefixedCdnBase', () => {
     const prefixCdnBase = 'https://ucarecd.net'
     expect(isPrefixedCdnBase(cdnBase, prefixCdnBase)).toBe(false)
   })
+
+  it('should return true for the prefixed zone itself (no subdomain)', () => {
+    expect(
+      isPrefixedCdnBase('https://ucarecd.net', 'https://ucarecd.net')
+    ).toBe(true)
+  })
+
+  it('should return false for a host that only ends with the zone string but is not a subdomain', () => {
+    // `notucarecd.net` shares the suffix `ucarecd.net` but is a different domain.
+    expect(
+      isPrefixedCdnBase('https://notucarecd.net', 'https://ucarecd.net')
+    ).toBe(false)
+  })
 })

--- a/packages/cname-prefix/src/common/isPrefixedCdnBase.ts
+++ b/packages/cname-prefix/src/common/isPrefixedCdnBase.ts
@@ -1,8 +1,11 @@
 export const isPrefixedCdnBase = (cdnBase: string, prefixCdnBase: string) => {
   try {
-    const cdnBaseUrl = new URL(cdnBase)
-    const prefixCdnBaseUrl = new URL(prefixCdnBase)
-    return cdnBaseUrl.hostname.endsWith(prefixCdnBaseUrl.hostname)
+    const host = new URL(cdnBase).hostname
+    const base = new URL(prefixCdnBase).hostname
+    // Match the zone itself or a subdomain of it, on a label boundary — so
+    // `ucarecd.net` and `<prefix>.ucarecd.net` match, but `notucarecd.net`
+    // (which merely ends with the same string) does not.
+    return host === base || host.endsWith(`.${base}`)
   } catch (_err) {
     return false
   }

--- a/packages/upload-client/README.md
+++ b/packages/upload-client/README.md
@@ -269,8 +269,7 @@ By default (when `baseCDN` is omitted) the client returns a **per-project
 prefixed** CDN URL derived from your `publicKey`, e.g.
 `https://<prefix>.ucarecd.net/<uuid>/`. Set `baseCDN` explicitly to use that
 exact domain verbatim instead — either the classic shared domain
-(`https://ucarecdn.com/`) or your own custom CNAME. See
-[Which CDN domain is used?](#faq) below.
+(`https://ucarecdn.com/`) or your own custom CNAME.
 
 Not set by default (prefixing is applied). Only affects `cdnUrl`; the Upload API
 endpoint is controlled by `baseURL`.
@@ -570,68 +569,6 @@ And then you can run test:
 ```
 npm run test:jest
 ```
-
-## FAQ
-
-### Which CDN domain is used?
-
-Starting with this version, uploaded files and groups get a **per-project
-prefixed** CDN URL **by default**:
-
-```typescript
-const file = await uploadFile(data, { publicKey: 'YOUR_PUBLIC_KEY' })
-file.cdnUrl // 'https://<prefix>.ucarecd.net/<uuid>/'
-```
-
-The `<prefix>` is derived from your `publicKey`. This matches the default
-behavior of the Uploadcare uploader (`blocks`) and other SDKs, so the whole
-family is consistent out of the box.
-
-The prefixed domain and the classic `ucarecdn.com` serve the same files, so
-URLs stored previously keep working.
-
-### How do I keep the legacy `ucarecdn.com` domain?
-
-Pass it explicitly as `baseCDN`. Any `baseCDN` you set is used **verbatim**, so
-prefixing is skipped:
-
-```typescript
-const file = await uploadFile(data, {
-  publicKey: 'YOUR_PUBLIC_KEY',
-  baseCDN: 'https://ucarecdn.com'
-})
-file.cdnUrl // 'https://ucarecdn.com/<uuid>/'
-```
-
-This is the recommended opt-out if you have, for example, a Content Security
-Policy (`img-src`/`connect-src`) or an allowlist pinned to `ucarecdn.com`.
-
-### How do I use my own custom CDN domain (CNAME)?
-
-Same mechanism — set `baseCDN` to your domain. It is used verbatim:
-
-```typescript
-const file = await uploadFile(data, {
-  publicKey: 'YOUR_PUBLIC_KEY',
-  baseCDN: 'https://cdn.example.com'
-})
-file.cdnUrl // 'https://cdn.example.com/<uuid>/'
-```
-
-### The rules, in short
-
-- `baseCDN` **omitted** → prefixed by default
-  (`https://<prefix>.ucarecd.net/...`).
-- `baseCDN` set to **any domain** (including `https://ucarecdn.com` or your
-  CNAME) → used **verbatim**, no prefixing.
-- `baseCDN` set to the **prefixed zone** itself (`https://ucarecd.net` or an
-  already-prefixed `https://<prefix>.ucarecd.net`) → re-derived to the correct
-  per-project prefix (idempotent), so passing an already-resolved base is safe.
-- Change the zone that prefixes are built from with
-  [`prefixedBaseCDN`](#prefixedbasecdn-string).
-
-All of the above apply per call and per `UploadClient` instance, so you can mix
-prefixed and legacy behavior across uploads.
 
 ## Security issues
 

--- a/packages/upload-client/README.md
+++ b/packages/upload-client/README.md
@@ -262,10 +262,25 @@ It is required when using Upload API.
 
 #### `baseCDN: string`
 
-Defines your schema and CDN domain. Can be changed to one of the predefined
-values (`https://ucarecdn.com/`) or your custom CNAME.
+Defines the schema and CDN domain used to build the `cdnUrl` of uploaded files
+and groups.
 
-Defaults to `https://ucarecdn.com/`.
+By default (when `baseCDN` is omitted) the client returns a **per-project
+prefixed** CDN URL derived from your `publicKey`, e.g.
+`https://<prefix>.ucarecd.net/<uuid>/`. Set `baseCDN` explicitly to use that
+exact domain verbatim instead — either the classic shared domain
+(`https://ucarecdn.com/`) or your own custom CNAME. See
+[Which CDN domain is used?](#faq) below.
+
+Not set by default (prefixing is applied). Only affects `cdnUrl`; the Upload API
+endpoint is controlled by `baseURL`.
+
+#### `prefixedBaseCDN: string`
+
+The base domain from which per-project prefixed CDN URLs are derived when
+prefixing is applied.
+
+Defaults to `https://ucarecd.net`.
 
 #### `baseURL: string`
 
@@ -555,6 +570,68 @@ And then you can run test:
 ```
 npm run test:jest
 ```
+
+## FAQ
+
+### Which CDN domain is used?
+
+Starting with this version, uploaded files and groups get a **per-project
+prefixed** CDN URL **by default**:
+
+```typescript
+const file = await uploadFile(data, { publicKey: 'YOUR_PUBLIC_KEY' })
+file.cdnUrl // 'https://<prefix>.ucarecd.net/<uuid>/'
+```
+
+The `<prefix>` is derived from your `publicKey`. This matches the default
+behavior of the Uploadcare uploader (`blocks`) and other SDKs, so the whole
+family is consistent out of the box.
+
+The prefixed domain and the classic `ucarecdn.com` serve the same files, so
+URLs stored previously keep working.
+
+### How do I keep the legacy `ucarecdn.com` domain?
+
+Pass it explicitly as `baseCDN`. Any `baseCDN` you set is used **verbatim**, so
+prefixing is skipped:
+
+```typescript
+const file = await uploadFile(data, {
+  publicKey: 'YOUR_PUBLIC_KEY',
+  baseCDN: 'https://ucarecdn.com'
+})
+file.cdnUrl // 'https://ucarecdn.com/<uuid>/'
+```
+
+This is the recommended opt-out if you have, for example, a Content Security
+Policy (`img-src`/`connect-src`) or an allowlist pinned to `ucarecdn.com`.
+
+### How do I use my own custom CDN domain (CNAME)?
+
+Same mechanism — set `baseCDN` to your domain. It is used verbatim:
+
+```typescript
+const file = await uploadFile(data, {
+  publicKey: 'YOUR_PUBLIC_KEY',
+  baseCDN: 'https://cdn.example.com'
+})
+file.cdnUrl // 'https://cdn.example.com/<uuid>/'
+```
+
+### The rules, in short
+
+- `baseCDN` **omitted** → prefixed by default
+  (`https://<prefix>.ucarecd.net/...`).
+- `baseCDN` set to **any domain** (including `https://ucarecdn.com` or your
+  CNAME) → used **verbatim**, no prefixing.
+- `baseCDN` set to the **prefixed zone** itself (`https://ucarecd.net` or an
+  already-prefixed `https://<prefix>.ucarecd.net`) → re-derived to the correct
+  per-project prefix (idempotent), so passing an already-resolved base is safe.
+- Change the zone that prefixes are built from with
+  [`prefixedBaseCDN`](#prefixedbasecdn-string).
+
+All of the above apply per call and per `UploadClient` instance, so you can mix
+prefixed and legacy behavior across uploads.
 
 ## Security issues
 

--- a/packages/upload-client/package.json
+++ b/packages/upload-client/package.json
@@ -90,6 +90,7 @@
     "@types/koa__router": "^12.0.4",
     "@types/ws": "8.5.3",
     "@uploadcare/api-client-utils": "^6.18.4",
+    "@uploadcare/cname-prefix": "^6.18.4",
     "chalk": "^4.1.2",
     "data-uri-to-buffer": "3.0.1",
     "dataurl-to-blob": "0.0.1",

--- a/packages/upload-client/src/defaultSettings.ts
+++ b/packages/upload-client/src/defaultSettings.ts
@@ -6,6 +6,7 @@ import { DefaultSettings } from './types'
  */
 const defaultSettings: DefaultSettings = {
   baseCDN: 'https://ucarecdn.com',
+  prefixedBaseCDN: 'https://ucarecd.net',
   baseURL: 'https://upload.uploadcare.com',
   maxContentLength: 50 * 1024 * 1024, // 50 MB
   retryThrottledRequestMaxTimes: 1,

--- a/packages/upload-client/src/tools/getPrefixedCdnBase.browser.ts
+++ b/packages/upload-client/src/tools/getPrefixedCdnBase.browser.ts
@@ -1,0 +1,11 @@
+// eslint-disable-next-line import/no-unresolved -- subpath export, resolved by bundler/TS
+import { getPrefixedCdnBaseAsync } from '@uploadcare/cname-prefix/async'
+
+/**
+ * Browser: derive the per-project prefixed CDN base via the WebCrypto SHA-256
+ * implementation, keeping the browser bundle free of the pure-JS fallback.
+ */
+export const getPrefixedCdnBase = (
+  publicKey: string,
+  cdnBase: string
+): Promise<string> => getPrefixedCdnBaseAsync(publicKey, cdnBase)

--- a/packages/upload-client/src/tools/getPrefixedCdnBase.node.ts
+++ b/packages/upload-client/src/tools/getPrefixedCdnBase.node.ts
@@ -1,0 +1,16 @@
+// eslint-disable-next-line import/no-unresolved -- subpath export, resolved by bundler/TS
+import { getPrefixedCdnBaseSync } from '@uploadcare/cname-prefix/sync'
+
+/**
+ * Node / React Native: derive the per-project prefixed CDN base synchronously
+ * (pure-JS SHA-256). Wrapped in a Promise so every environment shares one
+ * signature with the browser (WebCrypto) variant.
+ *
+ * The build replaces this `.node` import with the matching environment file via
+ * the rollup alias (see `createRollupConfig.js`).
+ */
+export const getPrefixedCdnBase = (
+  publicKey: string,
+  cdnBase: string
+): Promise<string> =>
+  Promise.resolve(getPrefixedCdnBaseSync(publicKey, cdnBase))

--- a/packages/upload-client/src/tools/getPrefixedCdnBase.react-native.ts
+++ b/packages/upload-client/src/tools/getPrefixedCdnBase.react-native.ts
@@ -1,0 +1,14 @@
+// eslint-disable-next-line import/no-unresolved -- subpath export, resolved by bundler/TS
+import { getPrefixedCdnBaseSync } from '@uploadcare/cname-prefix/sync'
+
+/**
+ * React Native: has no `window.crypto.subtle`, so it derives the per-project
+ * prefixed CDN base synchronously (pure-JS SHA-256), like Node. Kept
+ * self-contained rather than re-exporting the `.node` entry, since the build
+ * alias would rewrite that import to this file itself.
+ */
+export const getPrefixedCdnBase = (
+  publicKey: string,
+  cdnBase: string
+): Promise<string> =>
+  Promise.resolve(getPrefixedCdnBaseSync(publicKey, cdnBase))

--- a/packages/upload-client/src/tools/resolveCdnBase.ts
+++ b/packages/upload-client/src/tools/resolveCdnBase.ts
@@ -1,0 +1,34 @@
+import { isPrefixedCdnBase } from '@uploadcare/cname-prefix'
+import defaultSettings from '../defaultSettings'
+import { getPrefixedCdnBase } from './getPrefixedCdnBase.node'
+
+/**
+ * Resolve the effective CDN base used to build an uploaded file's `cdnUrl`.
+ *
+ * By default — or when an explicit `baseCDN` already points at the prefixed
+ * zone — the per-project prefixed base is derived from `publicKey` (e.g.
+ * `https://<prefix>.ucarecd.net`). Any other custom `baseCDN` is returned
+ * untouched, which is how callers opt out of prefixing.
+ *
+ * The `getPrefixedCdnBase` import is environment-split at build time: WebCrypto
+ * in the browser, pure-JS SHA-256 in Node / React Native.
+ */
+export const resolveCdnBase = ({
+  publicKey,
+  baseCDN = defaultSettings.baseCDN,
+  prefixedBaseCDN = defaultSettings.prefixedBaseCDN
+}: {
+  publicKey: string
+  baseCDN?: string
+  prefixedBaseCDN?: string
+}): Promise<string> => {
+  if (
+    publicKey &&
+    (baseCDN === defaultSettings.baseCDN ||
+      isPrefixedCdnBase(baseCDN, prefixedBaseCDN))
+  ) {
+    return getPrefixedCdnBase(publicKey, prefixedBaseCDN)
+  }
+
+  return Promise.resolve(baseCDN)
+}

--- a/packages/upload-client/src/tools/resolveCdnBase.ts
+++ b/packages/upload-client/src/tools/resolveCdnBase.ts
@@ -5,32 +5,35 @@ import { getPrefixedCdnBase } from './getPrefixedCdnBase.node'
 /**
  * Resolve the effective CDN base used to build an uploaded file's `cdnUrl`.
  *
- * By default — or when an explicit `baseCDN` already points at the prefixed
- * zone — the per-project prefixed base is derived from `publicKey` (e.g.
- * `https://<prefix>.ucarecd.net`). Any other custom `baseCDN` is returned
- * untouched, which is how callers opt out of prefixing.
+ * Prefixing is the default: when no `baseCDN` is provided — or when the
+ * provided `baseCDN` already points at the prefixed zone (idempotent
+ * re-derivation) — the per-project prefixed base is derived from `publicKey`
+ * (e.g. `https://<prefix>.ucarecd.net`).
+ *
+ * Any other explicitly provided `baseCDN` is used verbatim. That is how callers
+ * keep a legacy or custom domain — including the classic
+ * `https://ucarecdn.com`: pass it explicitly to opt out of prefixing.
  *
  * The `getPrefixedCdnBase` import is environment-split at build time: WebCrypto
  * in the browser, pure-JS SHA-256 in Node / React Native.
  */
 export const resolveCdnBase = ({
   publicKey,
-  baseCDN = defaultSettings.baseCDN,
+  baseCDN,
   prefixedBaseCDN = defaultSettings.prefixedBaseCDN
 }: {
   publicKey: string
   baseCDN?: string
   prefixedBaseCDN?: string
 }): Promise<string> => {
-  // Compare slash-insensitively so the documented default is recognised
-  // whether passed as `https://ucarecdn.com` or `https://ucarecdn.com/`.
-  const isDefaultBase =
-    baseCDN.replace(/\/+$/, '') === defaultSettings.baseCDN.replace(/\/+$/, '')
+  // Without a public key there is nothing to derive a prefix from.
+  if (!publicKey) {
+    return Promise.resolve(baseCDN ?? defaultSettings.baseCDN)
+  }
 
-  if (
-    publicKey &&
-    (isDefaultBase || isPrefixedCdnBase(baseCDN, prefixedBaseCDN))
-  ) {
+  // Prefix when the caller did not set a base, or explicitly targets the
+  // prefixed zone; any other explicit base is returned verbatim (opt-out).
+  if (baseCDN === undefined || isPrefixedCdnBase(baseCDN, prefixedBaseCDN)) {
     return getPrefixedCdnBase(publicKey, prefixedBaseCDN)
   }
 

--- a/packages/upload-client/src/tools/resolveCdnBase.ts
+++ b/packages/upload-client/src/tools/resolveCdnBase.ts
@@ -22,10 +22,14 @@ export const resolveCdnBase = ({
   baseCDN?: string
   prefixedBaseCDN?: string
 }): Promise<string> => {
+  // Compare slash-insensitively so the documented default is recognised
+  // whether passed as `https://ucarecdn.com` or `https://ucarecdn.com/`.
+  const isDefaultBase =
+    baseCDN.replace(/\/+$/, '') === defaultSettings.baseCDN.replace(/\/+$/, '')
+
   if (
     publicKey &&
-    (baseCDN === defaultSettings.baseCDN ||
-      isPrefixedCdnBase(baseCDN, prefixedBaseCDN))
+    (isDefaultBase || isPrefixedCdnBase(baseCDN, prefixedBaseCDN))
   ) {
     return getPrefixedCdnBase(publicKey, prefixedBaseCDN)
   }

--- a/packages/upload-client/src/tools/toUploadcareFile.ts
+++ b/packages/upload-client/src/tools/toUploadcareFile.ts
@@ -1,0 +1,30 @@
+import { FileInfo, GroupFileInfo } from '../api/types'
+import { resolveCdnBase } from './resolveCdnBase'
+import { UploadcareFile } from './UploadcareFile'
+
+/**
+ * Build an {@link UploadcareFile}, resolving the (prefixed-by-default) CDN base
+ * from `publicKey` before construction. See {@link resolveCdnBase}.
+ */
+export const toUploadcareFile = async (
+  fileInfo: FileInfo | GroupFileInfo,
+  {
+    publicKey,
+    baseCDN,
+    prefixedBaseCDN,
+    fileName
+  }: {
+    publicKey: string
+    baseCDN?: string
+    prefixedBaseCDN?: string
+    fileName?: string
+  }
+): Promise<UploadcareFile> => {
+  const resolvedBaseCDN = await resolveCdnBase({
+    publicKey,
+    baseCDN,
+    prefixedBaseCDN
+  })
+
+  return new UploadcareFile(fileInfo, { baseCDN: resolvedBaseCDN, fileName })
+}

--- a/packages/upload-client/src/tools/toUploadcareGroup.ts
+++ b/packages/upload-client/src/tools/toUploadcareGroup.ts
@@ -1,0 +1,28 @@
+import { GroupInfo } from '../api/types'
+import { resolveCdnBase } from './resolveCdnBase'
+import { UploadcareGroup } from './UploadcareGroup'
+
+/**
+ * Build an {@link UploadcareGroup}, resolving the (prefixed-by-default) CDN base
+ * from `publicKey` before construction. See {@link resolveCdnBase}.
+ */
+export const toUploadcareGroup = async (
+  groupInfo: GroupInfo,
+  {
+    publicKey,
+    baseCDN,
+    prefixedBaseCDN
+  }: {
+    publicKey: string
+    baseCDN?: string
+    prefixedBaseCDN?: string
+  }
+): Promise<UploadcareGroup> => {
+  const resolvedBaseCDN = await resolveCdnBase({
+    publicKey,
+    baseCDN,
+    prefixedBaseCDN
+  })
+
+  return new UploadcareGroup(groupInfo, { baseCDN: resolvedBaseCDN })
+}

--- a/packages/upload-client/src/types.ts
+++ b/packages/upload-client/src/types.ts
@@ -2,6 +2,11 @@ import { CustomUserAgent, StoreValue } from '@uploadcare/api-client-utils'
 
 export interface DefaultSettings {
   baseCDN: string
+  /**
+   * Base domain used to build per-project prefixed CDN URLs (default
+   * `https://ucarecd.net`).
+   */
+  prefixedBaseCDN: string
   baseURL: string
   maxContentLength: number
   retryThrottledRequestMaxTimes: number

--- a/packages/upload-client/src/uploadFile/uploadDirect.ts
+++ b/packages/upload-client/src/uploadFile/uploadDirect.ts
@@ -1,6 +1,7 @@
 import base from '../api/base'
 import { isReadyPoll } from '../tools/isReadyPoll'
 import { UploadcareFile } from '../tools/UploadcareFile'
+import { toUploadcareFile } from '../tools/toUploadcareFile'
 
 import {
   CustomUserAgent,
@@ -31,6 +32,7 @@ export type DirectOptions = {
   retryNetworkErrorMaxTimes?: number
 
   baseCDN?: string
+  prefixedBaseCDN?: string
   metadata?: Metadata
 }
 
@@ -57,6 +59,7 @@ export const uploadDirect = (
     retryNetworkErrorMaxTimes,
 
     baseCDN,
+    prefixedBaseCDN,
     metadata
   }: DirectOptions
 ): Promise<UploadcareFile> => {
@@ -90,5 +93,7 @@ export const uploadDirect = (
         signal
       })
     })
-    .then((fileInfo) => new UploadcareFile(fileInfo, { baseCDN }))
+    .then((fileInfo) =>
+      toUploadcareFile(fileInfo, { publicKey, baseCDN, prefixedBaseCDN })
+    )
 }

--- a/packages/upload-client/src/uploadFile/uploadFile.ts
+++ b/packages/upload-client/src/uploadFile/uploadFile.ts
@@ -43,6 +43,7 @@ export type FileFromOptions = {
   maxConcurrentRequests?: number
 
   baseCDN?: string
+  prefixedBaseCDN?: string
 
   checkForUrlDuplicates?: boolean
   saveUrlForRecurrentUploads?: boolean
@@ -80,6 +81,7 @@ export async function uploadFile(
     maxConcurrentRequests,
 
     baseCDN = defaultSettings.baseCDN,
+    prefixedBaseCDN = defaultSettings.prefixedBaseCDN,
 
     checkForUrlDuplicates,
     saveUrlForRecurrentUploads,
@@ -116,6 +118,7 @@ export async function uploadFile(
         retryNetworkErrorMaxTimes,
 
         baseCDN,
+        prefixedBaseCDN,
         metadata
       })
     }
@@ -141,6 +144,7 @@ export async function uploadFile(
       retryNetworkErrorMaxTimes,
 
       baseCDN,
+      prefixedBaseCDN,
       metadata
     })
   }
@@ -152,6 +156,7 @@ export async function uploadFile(
       fileName,
       baseURL,
       baseCDN,
+      prefixedBaseCDN,
       checkForUrlDuplicates,
       saveUrlForRecurrentUploads,
       secureSignature,
@@ -189,7 +194,8 @@ export async function uploadFile(
       retryThrottledRequestMaxTimes,
       retryNetworkErrorMaxTimes,
 
-      baseCDN
+      baseCDN,
+      prefixedBaseCDN
     })
   }
 

--- a/packages/upload-client/src/uploadFile/uploadFile.ts
+++ b/packages/upload-client/src/uploadFile/uploadFile.ts
@@ -80,7 +80,10 @@ export async function uploadFile(
     multipartChunkSize,
     maxConcurrentRequests,
 
-    baseCDN = defaultSettings.baseCDN,
+    // Left undefined on purpose when the caller omits it, so `resolveCdnBase`
+    // can distinguish "not set" (→ prefixed default) from an explicit base
+    // (→ used verbatim, e.g. the legacy `https://ucarecdn.com`).
+    baseCDN,
     prefixedBaseCDN = defaultSettings.prefixedBaseCDN,
 
     checkForUrlDuplicates,

--- a/packages/upload-client/src/uploadFile/uploadFromUploaded.ts
+++ b/packages/upload-client/src/uploadFile/uploadFromUploaded.ts
@@ -1,4 +1,5 @@
 import { UploadcareFile } from '../tools/UploadcareFile'
+import { toUploadcareFile } from '../tools/toUploadcareFile'
 import { isReadyPoll } from '../tools/isReadyPoll'
 
 /* Types */
@@ -23,6 +24,7 @@ export type FromUploadedOptions = {
   retryNetworkErrorMaxTimes?: number
 
   baseCDN?: string
+  prefixedBaseCDN?: string
 }
 
 export const uploadFromUploaded = (
@@ -38,7 +40,8 @@ export const uploadFromUploaded = (
     userAgent,
     retryThrottledRequestMaxTimes,
     retryNetworkErrorMaxTimes,
-    baseCDN
+    baseCDN,
+    prefixedBaseCDN
   }: FromUploadedOptions
 ): Promise<UploadcareFile> => {
   return isReadyPoll(uuid, {
@@ -51,5 +54,12 @@ export const uploadFromUploaded = (
     userAgent,
     retryThrottledRequestMaxTimes,
     retryNetworkErrorMaxTimes
-  }).then((fileInfo) => new UploadcareFile(fileInfo, { baseCDN, fileName }))
+  }).then((fileInfo) =>
+    toUploadcareFile(fileInfo, {
+      publicKey,
+      baseCDN,
+      prefixedBaseCDN,
+      fileName
+    })
+  )
 }

--- a/packages/upload-client/src/uploadFile/uploadFromUrl.ts
+++ b/packages/upload-client/src/uploadFile/uploadFromUrl.ts
@@ -13,6 +13,7 @@ import {
   poll
 } from '@uploadcare/api-client-utils'
 import { UploadcareFile } from '../tools/UploadcareFile'
+import { toUploadcareFile } from '../tools/toUploadcareFile'
 import { FileInfo, ProgressCallback } from '../api/types'
 
 function pollStrategy({
@@ -89,6 +90,7 @@ function pollStrategy({
 
 export type UploadFromUrlOptions = {
   baseCDN?: string
+  prefixedBaseCDN?: string
   onProgress?: ProgressCallback
   pusherKey?: string
 } & FromUrlOptions
@@ -159,6 +161,7 @@ export const uploadFromUrl = (
     fileName,
     baseURL,
     baseCDN,
+    prefixedBaseCDN,
     checkForUrlDuplicates,
     saveUrlForRecurrentUploads,
     secureSignature,
@@ -246,4 +249,6 @@ export const uploadFromUrl = (
         signal
       })
     })
-    .then((fileInfo) => new UploadcareFile(fileInfo, { baseCDN }))
+    .then((fileInfo) =>
+      toUploadcareFile(fileInfo, { publicKey, baseCDN, prefixedBaseCDN })
+    )

--- a/packages/upload-client/src/uploadFile/uploadMultipart.ts
+++ b/packages/upload-client/src/uploadFile/uploadMultipart.ts
@@ -13,6 +13,7 @@ import defaultSettings from '../defaultSettings'
 import { isReadyPoll } from '../tools/isReadyPoll'
 import runWithConcurrency from '../tools/runWithConcurrency'
 import { UploadcareFile } from '../tools/UploadcareFile'
+import { toUploadcareFile } from '../tools/toUploadcareFile'
 import { prepareChunks } from './prepareChunks.node'
 
 import {
@@ -44,6 +45,7 @@ export type MultipartOptions = {
   retryNetworkErrorMaxTimes?: number
   maxConcurrentRequests?: number
   baseCDN?: string
+  prefixedBaseCDN?: string
   metadata?: Metadata
 }
 
@@ -97,6 +99,7 @@ export const uploadMultipart = async (
     maxConcurrentRequests = defaultSettings.maxConcurrentRequests,
 
     baseCDN,
+    prefixedBaseCDN,
     metadata
   }: MultipartOptions
 ): Promise<UploadcareFile> => {
@@ -194,5 +197,7 @@ export const uploadMultipart = async (
         signal
       })
     })
-    .then((fileInfo) => new UploadcareFile(fileInfo, { baseCDN }))
+    .then((fileInfo) =>
+      toUploadcareFile(fileInfo, { publicKey, baseCDN, prefixedBaseCDN })
+    )
 }

--- a/packages/upload-client/src/uploadFileGroup/uploadFileGroup.ts
+++ b/packages/upload-client/src/uploadFileGroup/uploadFileGroup.ts
@@ -1,6 +1,7 @@
 import group from '../api/group'
 import defaultSettings from '../defaultSettings'
 import { UploadcareGroup } from '../tools/UploadcareGroup'
+import { toUploadcareGroup } from '../tools/toUploadcareGroup'
 import { FileFromOptions, uploadFile } from '../uploadFile'
 
 /* Types */
@@ -45,6 +46,7 @@ export function uploadFileGroup(
     multipartChunkSize = defaultSettings.multipartChunkSize,
 
     baseCDN = defaultSettings.baseCDN,
+    prefixedBaseCDN = defaultSettings.prefixedBaseCDN,
     checkForUrlDuplicates,
     saveUrlForRecurrentUploads,
 
@@ -108,6 +110,7 @@ export function uploadFileGroup(
             multipartChunkSize,
 
             baseCDN,
+            prefixedBaseCDN,
             checkForUrlDuplicates,
             saveUrlForRecurrentUploads
           }).then((fileInfo) => fileInfo.uuid)
@@ -131,7 +134,9 @@ export function uploadFileGroup(
       retryThrottledRequestMaxTimes,
       retryNetworkErrorMaxTimes
     })
-      .then((groupInfo) => new UploadcareGroup(groupInfo, { baseCDN }))
+      .then((groupInfo) =>
+        toUploadcareGroup(groupInfo, { publicKey, baseCDN, prefixedBaseCDN })
+      )
       .then((group) => {
         onProgress && onProgress({ isComputable: true, value: 1 })
         return group

--- a/packages/upload-client/src/uploadFileGroup/uploadFileGroup.ts
+++ b/packages/upload-client/src/uploadFileGroup/uploadFileGroup.ts
@@ -45,7 +45,10 @@ export function uploadFileGroup(
     contentType,
     multipartChunkSize = defaultSettings.multipartChunkSize,
 
-    baseCDN = defaultSettings.baseCDN,
+    // Left undefined on purpose when the caller omits it, so `resolveCdnBase`
+    // can distinguish "not set" (→ prefixed default) from an explicit base
+    // (→ used verbatim, e.g. the legacy `https://ucarecdn.com`).
+    baseCDN,
     prefixedBaseCDN = defaultSettings.prefixedBaseCDN,
     checkForUrlDuplicates,
     saveUrlForRecurrentUploads,

--- a/packages/upload-client/test/tools/resolveCdnBase.test.ts
+++ b/packages/upload-client/test/tools/resolveCdnBase.test.ts
@@ -1,0 +1,48 @@
+// eslint-disable-next-line import/no-unresolved -- subpath export, resolved by bundler/TS
+import { getPrefixedCdnBaseSync } from '@uploadcare/cname-prefix/sync'
+import { expect } from '@jest/globals'
+import { resolveCdnBase } from '../../src/tools/resolveCdnBase'
+import { defaultSettings } from '../../src/defaultSettings'
+
+const publicKey = 'demopublickey'
+const expectedPrefixed = getPrefixedCdnBaseSync(
+  publicKey,
+  defaultSettings.prefixedBaseCDN
+)
+
+describe('resolveCdnBase', () => {
+  it('derives the prefixed base from the public key by default', async () => {
+    await expect(resolveCdnBase({ publicKey })).resolves.toBe(expectedPrefixed)
+    expect(expectedPrefixed).toMatch(/^https:\/\/[a-z0-9]+\.ucarecd\.net$/)
+  })
+
+  it('derives the prefixed base when baseCDN is the default', async () => {
+    await expect(
+      resolveCdnBase({ publicKey, baseCDN: defaultSettings.baseCDN })
+    ).resolves.toBe(expectedPrefixed)
+  })
+
+  it('re-derives when an explicit base already points at the prefixed zone', async () => {
+    await expect(
+      resolveCdnBase({ publicKey, baseCDN: 'https://stale1234.ucarecd.net' })
+    ).resolves.toBe(expectedPrefixed)
+  })
+
+  it('leaves a custom baseCDN untouched (opt-out)', async () => {
+    await expect(
+      resolveCdnBase({ publicKey, baseCDN: 'https://cdn.example.com' })
+    ).resolves.toBe('https://cdn.example.com')
+  })
+
+  it('honours a custom prefixedBaseCDN', async () => {
+    await expect(
+      resolveCdnBase({ publicKey, prefixedBaseCDN: 'https://example.net' })
+    ).resolves.toBe(getPrefixedCdnBaseSync(publicKey, 'https://example.net'))
+  })
+
+  it('returns the base unchanged when no public key is provided', async () => {
+    await expect(
+      resolveCdnBase({ publicKey: '', baseCDN: defaultSettings.baseCDN })
+    ).resolves.toBe(defaultSettings.baseCDN)
+  })
+})

--- a/packages/upload-client/test/tools/resolveCdnBase.test.ts
+++ b/packages/upload-client/test/tools/resolveCdnBase.test.ts
@@ -16,22 +16,22 @@ describe('resolveCdnBase', () => {
     expect(expectedPrefixed).toMatch(/^https:\/\/[a-z0-9]+\.ucarecd\.net$/)
   })
 
-  it('derives the prefixed base when baseCDN is the default', async () => {
+  it('keeps the classic domain verbatim when passed explicitly (legacy opt-out)', async () => {
     await expect(
       resolveCdnBase({ publicKey, baseCDN: defaultSettings.baseCDN })
-    ).resolves.toBe(expectedPrefixed)
+    ).resolves.toBe(defaultSettings.baseCDN)
   })
 
-  it('accepts the documented default https://ucarecdn.com explicitly', async () => {
+  it('keeps https://ucarecdn.com verbatim when passed explicitly', async () => {
     await expect(
       resolveCdnBase({ publicKey, baseCDN: 'https://ucarecdn.com' })
-    ).resolves.toBe(expectedPrefixed)
+    ).resolves.toBe('https://ucarecdn.com')
   })
 
-  it('accepts the default with a trailing slash (https://ucarecdn.com/)', async () => {
+  it('keeps an explicit base with a trailing slash verbatim', async () => {
     await expect(
       resolveCdnBase({ publicKey, baseCDN: 'https://ucarecdn.com/' })
-    ).resolves.toBe(expectedPrefixed)
+    ).resolves.toBe('https://ucarecdn.com/')
   })
 
   it('re-derives when an explicit base already points at the prefixed zone', async () => {

--- a/packages/upload-client/test/tools/resolveCdnBase.test.ts
+++ b/packages/upload-client/test/tools/resolveCdnBase.test.ts
@@ -22,6 +22,18 @@ describe('resolveCdnBase', () => {
     ).resolves.toBe(expectedPrefixed)
   })
 
+  it('accepts the documented default https://ucarecdn.com explicitly', async () => {
+    await expect(
+      resolveCdnBase({ publicKey, baseCDN: 'https://ucarecdn.com' })
+    ).resolves.toBe(expectedPrefixed)
+  })
+
+  it('accepts the default with a trailing slash (https://ucarecdn.com/)', async () => {
+    await expect(
+      resolveCdnBase({ publicKey, baseCDN: 'https://ucarecdn.com/' })
+    ).resolves.toBe(expectedPrefixed)
+  })
+
   it('re-derives when an explicit base already points at the prefixed zone', async () => {
     await expect(
       resolveCdnBase({ publicKey, baseCDN: 'https://stale1234.ucarecd.net' })

--- a/packages/upload-client/test/tools/toUploadcareFile.test.ts
+++ b/packages/upload-client/test/tools/toUploadcareFile.test.ts
@@ -1,0 +1,49 @@
+// eslint-disable-next-line import/no-unresolved -- subpath export, resolved by bundler/TS
+import { getPrefixedCdnBaseSync } from '@uploadcare/cname-prefix/sync'
+import { expect } from '@jest/globals'
+import { toUploadcareFile } from '../../src/tools/toUploadcareFile'
+import { defaultSettings } from '../../src/defaultSettings'
+import { FileInfo } from '../../src/api/types'
+
+const publicKey = 'demopublickey'
+const uuid = '12345678-aaaa-bbbb-cccc-000000000001'
+
+const fileInfo = {
+  size: 100,
+  done: 100,
+  total: 100,
+  uuid,
+  fileId: uuid,
+  originalFilename: 'photo.jpg',
+  filename: 'photo.jpg',
+  mimeType: 'image/jpeg',
+  isImage: true,
+  isStored: true,
+  isReady: true,
+  imageInfo: null,
+  videoInfo: null,
+  contentInfo: null,
+  s3Bucket: undefined,
+  metadata: undefined
+} as FileInfo
+
+describe('toUploadcareFile', () => {
+  it('builds cdnUrl on the prefixed base by default', async () => {
+    const file = await toUploadcareFile(fileInfo, { publicKey })
+    const expectedBase = getPrefixedCdnBaseSync(
+      publicKey,
+      defaultSettings.prefixedBaseCDN
+    )
+
+    expect(file.cdnUrl).toBe(`${expectedBase}/${uuid}/`)
+  })
+
+  it('keeps a custom baseCDN untouched', async () => {
+    const file = await toUploadcareFile(fileInfo, {
+      publicKey,
+      baseCDN: 'https://cdn.example.com'
+    })
+
+    expect(file.cdnUrl).toBe(`https://cdn.example.com/${uuid}/`)
+  })
+})

--- a/packages/upload-client/test/tools/toUploadcareGroup.test.ts
+++ b/packages/upload-client/test/tools/toUploadcareGroup.test.ts
@@ -1,0 +1,63 @@
+// eslint-disable-next-line import/no-unresolved -- subpath export, resolved by bundler/TS
+import { getPrefixedCdnBaseSync } from '@uploadcare/cname-prefix/sync'
+import { expect } from '@jest/globals'
+import { toUploadcareGroup } from '../../src/tools/toUploadcareGroup'
+import { defaultSettings } from '../../src/defaultSettings'
+import { GroupFileInfo, GroupInfo } from '../../src/api/types'
+
+const publicKey = 'demopublickey'
+const groupId = '12345678-aaaa-bbbb-cccc-000000000000~2'
+const fileUuid = '12345678-aaaa-bbbb-cccc-000000000001'
+
+const createFile = (overrides: Partial<GroupFileInfo> = {}): GroupFileInfo => ({
+  size: 100,
+  done: 100,
+  total: 100,
+  uuid: fileUuid,
+  fileId: fileUuid,
+  originalFilename: 'photo.jpg',
+  filename: 'photo.jpg',
+  mimeType: 'image/jpeg',
+  isImage: true,
+  isStored: true,
+  isReady: true,
+  imageInfo: null,
+  videoInfo: null,
+  contentInfo: null,
+  metadata: undefined,
+  defaultEffects: '-/resize/640x/',
+  ...overrides
+})
+
+const groupInfo: GroupInfo = {
+  datetimeCreated: '2024-01-01T00:00:00Z',
+  datetimeStored: '2024-01-02T00:00:00Z',
+  filesCount: '1',
+  cdnUrl: `https://ucarecdn.com/${groupId}/`,
+  files: [createFile()],
+  url: 'https://uploadcare.com/groups/12345678-aaaa-bbbb-cccc-000000000000/',
+  id: groupId
+}
+
+describe('toUploadcareGroup', () => {
+  it('builds group and member cdnUrls on the prefixed base by default', async () => {
+    const group = await toUploadcareGroup(groupInfo, { publicKey })
+    const expectedBase = getPrefixedCdnBaseSync(
+      publicKey,
+      defaultSettings.prefixedBaseCDN
+    )
+
+    expect(group.cdnUrl).toBe(`${expectedBase}/${groupId}/`)
+    expect(group.files[0].cdnUrl).toBe(`${expectedBase}/${fileUuid}/`)
+  })
+
+  it('keeps a custom baseCDN untouched', async () => {
+    const group = await toUploadcareGroup(groupInfo, {
+      publicKey,
+      baseCDN: 'https://cdn.example.com'
+    })
+
+    expect(group.cdnUrl).toBe(`https://cdn.example.com/${groupId}/`)
+    expect(group.files[0].cdnUrl).toBe(`https://cdn.example.com/${fileUuid}/`)
+  })
+})


### PR DESCRIPTION
## What

`@uploadcare/upload-client` now returns per-project **prefixed CDN domains by default**. Uploaded files and groups get a `cdnUrl` like `https://<prefix>.ucarecd.net/<uuid>/` (the `<prefix>` is derived from the public key) instead of the shared `https://ucarecdn.com/<uuid>/`.

This matches the default behavior already shipped in **blocks** (the uploader) and **ai-enhancer**, both of which resolve the prefixed base via `@uploadcare/cname-prefix` and pass it into upload-client. Moving the default into upload-client means the whole SDK family is consistent out of the box.

`baseURL` (the Upload API endpoint) is unaffected — this only changes the delivery `cdnUrl` built on the returned file/group objects.

## How

- **`resolveCdnBase`** — derives the prefixed base when `baseCDN` is the default (`https://ucarecdn.com`) **or** already points at the prefixed zone (`isPrefixedCdnBase`); any other custom `baseCDN` is returned untouched, which is how callers opt out. The derivation is **idempotent**, so SDKs that already pass a resolved `<prefix>.ucarecd.net` base get the same value back (no double-prefixing).
- **Environment-split derivation** via the existing rollup `.node`→`.<env>` alias:
  - browser → `@uploadcare/cname-prefix/async` (WebCrypto)
  - Node / React Native → `@uploadcare/cname-prefix/sync` (pure-JS; no `window.crypto`)

  The browser bundle never ships the pure-JS SHA-256, and Node/RN never reference `window.crypto`.
- **`toUploadcareFile` / `toUploadcareGroup`** resolve the base, then construct. All five upload leaf-flows (`uploadDirect`, `uploadMultipart`, `uploadFromUrl`, `uploadFromUploaded`, `uploadFileGroup`) route through them.
- New overridable **`prefixedBaseCDN`** setting (default `https://ucarecd.net`).

## Opt-out / compatibility

Set any custom `baseCDN` to disable prefixing (returned as-is). Both domains serve the same files, so existing stored URLs continue to work. Targeting a **minor / alpha** release.

## Verification

- `npm run build` green — all six bundles; env-split confirmed by inspecting the built bundles (Node/RN carry the sync impl, browser carries only WebCrypto).
- `tsc` (source), ESLint, Prettier all clean.
- New unit tests: `resolveCdnBase`, `toUploadcareFile`, `toUploadcareGroup` (default→prefixed, custom→untouched, already-prefixed→re-derived, no-publicKey→untouched).
- Existing integration tests unaffected (they use a custom localhost `baseCDN`, which is treated as opt-out).

> Note: `@uploadcare/cname-prefix` is added as a **devDependency** because the build bundles all `@uploadcare/*` packages (rollup `nodeExternals` excludes them), consistent with `@uploadcare/api-client-utils`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)